### PR TITLE
Update Dockerfile to use workdir command

### DIFF
--- a/docker/ubuntu-18.04/Dockerfile
+++ b/docker/ubuntu-18.04/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+WORKDIR /workdir
+
 RUN apt update
 RUN apt install -yqq build-essential
 RUN apt install -yqq sudo
@@ -12,5 +14,3 @@ RUN apt install -yqq git
 RUN apt install -yqq wget 
 RUN apt install -yqq ca-certificates 
 RUN apt install -yqq uuid-runtime
-
-RUN mkdir /workdir


### PR DESCRIPTION
Update Dockerfile to use workdir command to be able to start the container in the working directory