### PR TITLE
workdir: Do not copy base files if absent

### DIFF
--- a/workdir/fill-workdir.sh
+++ b/workdir/fill-workdir.sh
@@ -15,7 +15,9 @@ pushd libs > /dev/null 2>&1
 ./clone-all.sh
 popd > /dev/null 2>&1
 
-cp -r copy/base/* .
+if stat -t copy/base/* > /dev/null 2>&1; then
+   cp -r copy/base/* .
+fi
 
 apps=(apps/*/)
 for a in ${apps[@]}; do


### PR DESCRIPTION
In `fill_workdir.sh`, if `copy/base/*` expands to no files, do not copy them. Previously, this showed an error that was confusing and let the user think something bad happened.