### PR TITLE
docker: Add Docker configuration fo Ubuntu 23.04

### DIFF
--- a/docker/ubuntu-23.04/Dockerfile
+++ b/docker/ubuntu-23.04/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:23.04
+
+RUN apt update
+RUN apt install -yqq build-essential
+RUN apt install -yqq make
+RUN apt install -yqq gcc
+RUN apt install -yqq gcc-12
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12
+RUN apt install -y gccgo
+RUN apt install -y gccgo-12
+RUN update-alternatives --install /usr/bin/gccgo gccgo /usr/bin/gccgo-12 12
+RUN apt install -yqq clang
+RUN apt install -yqq python3
+RUN apt install -yqq gawk sed
+RUN apt install -yqq sudo less
+RUN apt install -yqq libncurses5 libncurses5-dev libncursesw5
+RUN apt install -yqq flex bison
+RUN apt install -yqq wget ca-certificates
+RUN apt install -yqq golang
+RUN apt install -yqq unzip
+RUN apt install -yqq vim
+RUN apt install -yqq gcc-aarch64-linux-gnu
+RUN apt install -yqq g++-aarch64-linux-gnu
+RUN apt install -yqq uuid-runtime
+RUN apt install -yqq qemu-system-x86
+RUN apt install -yqq qemu-system-arm
+RUN apt install -yqq sgabios
+
+WORKDIR /workdir

--- a/docker/ubuntu-23.04/Makefile
+++ b/docker/ubuntu-23.04/Makefile
@@ -1,0 +1,24 @@
+IMAGE_NAME = unikraft-ubuntu-23.04
+CONTAINER_NAME = $(IMAGE_NAME)
+LOCAL_MOUNT = $(shell pwd)/../../
+DOCKER_MOUNT = /workdir
+
+build:
+	docker build -f Dockerfile -t $(IMAGE_NAME) .
+
+run: build
+	docker run -d --name $(CONTAINER_NAME) -it -v $(LOCAL_MOUNT):$(DOCKER_MOUNT) $(IMAGE_NAME) /bin/bash
+
+enter:
+	docker exec -it $(CONTAINER_NAME) /bin/bash
+
+stop:
+	-docker stop $(CONTAINER_NAME)
+
+clean: stop
+	-docker rm $(CONTAINER_NAME)
+
+cleanimg: clean
+	-docker image rm $(IMAGE_NAME)
+
+.PHONY: build run stop clean


### PR DESCRIPTION
This is to be used for Unikraft C++ and Go builds. These rely on GCC 12, which if part of Ubuntu 23.04.